### PR TITLE
Mapper updates

### DIFF
--- a/aliases/mapper_aliases.xml
+++ b/aliases/mapper_aliases.xml
@@ -78,7 +78,7 @@ end</script>
 					<name>Show Areas</name>
 					<script>--syntax: arealist
 
-wotmudmapper:showAreaList()</script>
+wotmudmapper:show_area_list()</script>
 					<command></command>
 					<packageName></packageName>
 					<regex>^arealist$</regex>
@@ -88,7 +88,7 @@ wotmudmapper:showAreaList()</script>
 					<script>local areaid = getAreaTable()[matches[2]]
 
 if areaid then
-  wotmudmapper:showRoomList(areaid)
+  wotmudmapper:show_room_list(areaid)
 else
   wotmudmapper:echo("Area ("..matches[2]..") not known.\n",false,true)
 end</script>
@@ -547,7 +547,7 @@ end</script>
 wotmudmapper.map_colors = table.deepcopy(wotmudmapper.default_map_colors)
 wotmudmapper:echo("Map colors reset to default values.\n")
 table.save(getMudletHomeDir() .. "/wotmudmapper.map_colors.lua", wotmudmapper.map_colors)
-wotmudmapper:setMapColors()</script>
+wotmudmapper:set_map_colors()</script>
 					<command></command>
 					<packageName></packageName>
 					<regex>^map colors reset$</regex>
@@ -574,7 +574,7 @@ if wotmudmapper.map_colors[env] ~= nil then
     )
     wotmudmapper.map_colors[env] = color
     table.save(getMudletHomeDir() .. "/wotmudmapper.map_colors.lua", wotmudmapper.map_colors)
-    wotmudmapper:setMapColors()
+    wotmudmapper:set_map_colors()
   else
     wotmudmapper:echo("Color not known.\n", false, true)
   end
@@ -968,7 +968,7 @@ if wotmudmapper.configs.map_window[key]~=nil then
       wotmudmapper.configs.map_window[key] = val
       wotmudmapper:echo("Map window ("..key..") updated to ("..val..").\n")
       table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.configs)
-      wotmudmapper:showMap(true)
+      wotmudmapper:show_map(true)
     end
   elseif key == "h" then
     if (not tonumber(val)) or (tonumber(val) &lt; 1) then
@@ -978,7 +978,7 @@ if wotmudmapper.configs.map_window[key]~=nil then
       wotmudmapper.configs.map_window[key] = val
       wotmudmapper:echo("Map window ("..key..") updated to ("..val..").\n")
       table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.configs)
-      wotmudmapper:showMap(true)
+      wotmudmapper:show_map(true)
     end
   elseif key == "x" then
     if not tonumber(val) then
@@ -988,7 +988,7 @@ if wotmudmapper.configs.map_window[key]~=nil then
       wotmudmapper.configs.map_window[key] = val
       wotmudmapper:echo("Map window ("..key..") updated to ("..val..").\n")
       table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.configs)
-      wotmudmapper:showMap(true)
+      wotmudmapper:show_map(true)
     end
   elseif key == "y" then
     if not tonumber(val) then
@@ -998,7 +998,7 @@ if wotmudmapper.configs.map_window[key]~=nil then
       wotmudmapper.configs.map_window[key] = val
       wotmudmapper:echo("Map window ("..key..") updated to ("..val..").\n")
       table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.configs)
-      wotmudmapper:showMap(true)
+      wotmudmapper:show_map(true)
     end
   else
     wotmudmapper:echo("Key ("..key..") unable to be changed through this alias.\n",false,true)
@@ -1031,7 +1031,7 @@ end</script>
 				<script>wotmudmapper.configs.map_window.dock = not wotmudmapper.configs.map_window.dock
 wotmudmapper:echo("Map will now be "..(wotmudmapper.configs.map_window.dock and "docked.\n" or "floating.\n")) 
 table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.configs)
-wotmudmapper:showMap(wotmudmapper.configs.map_window.visible)</script>
+wotmudmapper:show_map(wotmudmapper.configs.map_window.visible)</script>
 				<command></command>
 				<packageName></packageName>
 				<regex>^map dock$</regex>
@@ -1041,7 +1041,7 @@ wotmudmapper:showMap(wotmudmapper.configs.map_window.visible)</script>
 				<script>wotmudmapper.configs.map_window.visible = not wotmudmapper.configs.map_window.visible
 wotmudmapper:echo("Map will now be "..(wotmudmapper.configs.map_window.visible and "shown.\n" or "hidden.\n"))
 table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.configs)
-wotmudmapper:showMap(wotmudmapper.configs.map_window.visible)</script>
+wotmudmapper:show_map(wotmudmapper.configs.map_window.visible)</script>
 				<command></command>
 				<packageName></packageName>
 				<regex>^map show$</regex>
@@ -1058,7 +1058,7 @@ wotmudmapper:showMap(wotmudmapper.configs.map_window.visible)</script>
 				<script>wotmudmapper.configs = table.deepcopy(wotmudmapper.defaults)
 wotmudmapper.configs.dbug = false
 wotmudmapper:echo("Map configurations reset to default values.\n")
-wotmudmapper:showMap(true)</script>
+wotmudmapper:show_map(true)</script>
 				<command></command>
 				<packageName></packageName>
 				<regex>^map configs reset$</regex>

--- a/aliases/mapper_aliases.xml
+++ b/aliases/mapper_aliases.xml
@@ -844,6 +844,28 @@ table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.confi
 				</Alias>
 			</AliasGroup>
 			<Alias isActive="yes" isFolder="no">
+				<name>Speedwalk Alias</name>
+				<script>local com = matches[1]
+
+comlist = com:gmatch("%d*[neswud]")
+
+for v in comlist do
+  local num = v:split("[neswud]")[1]
+  local dir = v:split(num)[2] or v:split(num)[1]
+  
+  if num == "" then
+    num = 1
+  end
+  
+  for i=1,tonumber(num),1 do
+    send(dir,false)
+  end
+end</script>
+				<command></command>
+				<packageName></packageName>
+				<regex>^\.(\d*[neswud])+$</regex>
+			</Alias>
+			<Alias isActive="yes" isFolder="no">
 				<name>Reset Queue</name>
 				<script>--syntax: resetqueue
 

--- a/scripts/mapper_scripts.xml
+++ b/scripts/mapper_scripts.xml
@@ -452,7 +452,7 @@ registerAnonymousEventHandler("AdjustableContainerRepositionFinish", "MapFinishe
     cmd = 1
   end
   for w in self.help[cmd]:gmatch("(.-)\n") do
-    local before, target, text, after = w:match("(.*)&lt;link: (.*)&gt;(.*)&lt;\/link&gt;(.*)")
+    local before, target, text, after = w:match("(.*)&lt;link: (.*)&gt;(.*)&lt;/link&gt;(.*)")
     if target then
       cecho(before)
       fg("yellow")

--- a/scripts/mapper_scripts.xml
+++ b/scripts/mapper_scripts.xml
@@ -5,50 +5,52 @@
 		<ScriptGroup isActive="yes" isFolder="yes">
 			<name>Mapper</name>
 			<packageName></packageName>
-			<script>mudlet = mudlet or {}
+			<script>--define mudlet required mapper variables and wotmudmapper table
+mudlet = mudlet or {}
 mudlet.mapper_script = true
 wotmudmapper = wotmudmapper or {}
 
 --mapper variables
-wotmudmapper.currentID = {}
-wotmudmapper.roomname = ""
-wotmudmapper.roomdesc = ""
-wotmudmapper.roomexits = {}
-wotmudmapper.zone = ""
-wotmudmapper.brief = false
-wotmudmapper.dark = false
-wotmudmapper.flee = false
-wotmudmapper.following = false
-wotmudmapper.door = "n"
-wotmudmapper.pausing = false
-wotmudmapper.inways = false
+wotmudmapper.currentID = {} --table to hold list of possible current room IDs
+wotmudmapper.roomname = "" --current room name captured by triggers
+wotmudmapper.roomdesc = "" --current room description captured by triggers
+wotmudmapper.roomexits = {} --table to hold list of room exits captured by triggers. list may include exits not in the map data. map data may include exits not in the list.
+wotmudmapper.zone = "" --current zone name pulled from map data
+wotmudmapper.brief = false --true only if wotmudmapper.roomdesc is empty string
+wotmudmapper.dark = false --true only if night/blind/fog triggers match
+wotmudmapper.flee = false --used by triggers to determine whether most recent movement was a manual flee or autoflee
+wotmudmapper.following = false --set to true on "You follow (.+)\.$"
+wotmudmapper.door = "n" --variable to hold door direction. only used in mapping mode to create doors
+wotmudmapper.pausing = false --variable used to pause and reset queue if long mud output (e.g. two page who list) is encountered
+wotmudmapper.inways = false --true only if wotmudmapper.roomname matches a room name from inside The Ways zone
 
 --default configuration values to be used or updated in wotmudmapper.configs
 wotmudmapper.defaults = {
-  mapping=false,
-  dbug=true,
-  mapbrief=false,
-  bothways=true,
-  autojoin=false,
-  forceroom=false,
-  envcolor=20,
-  offline=false,
-  roomID=1,
-  showzone = true,
-  zonecolor = "turquoise",
-  doorcolor = "blue",
-  map_window={
-    widget = false,
-    visible=true,
-    x="-37%",
-    y="0%",
-    w="37%",
-    h="73%",
-    zoom=50,
-    dock=false}
+  mapping = false, --true if mapping mode is turned on
+  dbug = true, --debug for echoing messages
+  mapbrief = false, --true if map triggers should manually delete room description lines from the screen
+  bothways = true, --true if new room and old room should be connected both ways in mapping mode
+  autojoin = false, --true if rooms should be auto-connected based on exits and proximity in mapping mode
+  forceroom = false, --true if a new room should be force created in mapping mode
+  envcolor = 20, --default environment number for mapping
+  offline = false, --true if map is being used in offline mode
+  roomID = 1, --last known room ID before profile is shut down
+  showzone = true, --true if zone information should be displayed below room exits
+  zonecolor = "turquoise", --color of zone information displayed below room exits
+  doorcolor = "blue", --color of door information displayed below room exits
+  map_window = {
+    widget = false, --true if the map widget should be used instead of an Adjustable.Container
+    visible = true, --true if map should be shown
+    x = "-37%", --left border of map Adjustable.Container
+    y = "0%", --top border of map Adjustable.Container
+    w = "37%", --width of map Adjustable.container
+    h = "73%", --height of map Adjustable.container
+    zoom = 50, --map window zoom level
+    dock = false --true if map Adjustable.Container can be docked to left or right of screen
+    }
   }
 
---set default map room type environment numbers and colors
+--default map room type environment numbers and colors
 wotmudmapper.room_type_env_nums = {
   inside = 20,
   wilderness = 21,
@@ -69,7 +71,6 @@ wotmudmapper.room_type_env_nums = {
   hunter = 36,
   pk = 37
 }
-
 wotmudmapper.default_map_colors = {
   inside = "white",
   wilderness = "forest_green",
@@ -91,7 +92,7 @@ wotmudmapper.default_map_colors = {
   pk = "light_gray"
 }
 
-
+--table of exit to number associations
 if not wotmudmapper.exitmap then
   wotmudmapper.exitmap =
     {
@@ -132,6 +133,8 @@ if not wotmudmapper.exitmap then
     }
 end
 
+
+--List functions
 List = {}
 
 function List:new()
@@ -140,8 +143,6 @@ function List:new()
   self.__index = self
   return list
 end
-
-wotmudmapper.queue = List:new()
 
 function List:pushright(value)
   local last = self.last + 1
@@ -169,17 +170,24 @@ end
 
 function List:checkleftvalue()
   return self[self.first]
-end</script>
+end
+
+--queue to store movement commands
+wotmudmapper.queue = List:new()</script>
 			<eventHandlerList />
 			<Script isActive="yes" isFolder="no">
 				<name>Mapper Display Echo</name>
 				<packageName></packageName>
 				<script>function wotmudmapper:echo(what, debug, err)
+  --colored tags for message echo
   local map_tag = "&lt;lawn_green&gt;(&lt;forest_green&gt;wotmudmapper&lt;lawn_green&gt;): &lt;white&gt;"
   local debug_tag = "&lt;deep_sky_blue&gt;(&lt;royal_blue&gt;debug&lt;deep_sky_blue&gt;): &lt;white&gt;"
   local err_tag = "&lt;coral&gt;(&lt;red&gt;error&lt;coral&gt;): &lt;white&gt;"
   
+  --if debug message and mapper debug is false, return without echoing
   if debug and not self.configs.dbug then return end
+  
+  --if start of message is new line, print that before colored tags of message echo
   if what:sub(0,1)=="\n" then
     cecho("\n")
     what = what:sub(2)
@@ -194,11 +202,15 @@ end</script>
 			<Script isActive="yes" isFolder="no">
 				<name>Set Map Colors</name>
 				<packageName></packageName>
-				<script>function wotmudmapper:setMapColors()
-  for k, v in pairs(self.map_colors) do
-    local r, g, b = unpack(color_table[v])
-    setCustomEnvColor(self.room_type_env_nums[k], r, g, b, 255)
+				<script>function wotmudmapper:set_map_colors()
+  --loop over environments and colors in color table
+  for env, color in pairs(self.map_colors) do
+    --unpack rgb values from mudlet color table
+    local r, g, b = unpack(color_table[color])
+    --set environment color for the given environment with the rgb values of the color
+    setCustomEnvColor(self.room_type_env_nums[env], r, g, b, 255)
   end
+  --update map display
   updateMap()
 end</script>
 				<eventHandlerList />
@@ -206,29 +218,31 @@ end</script>
 			<Script isActive="yes" isFolder="no">
 				<name>Set Map Configuration Values</name>
 				<packageName></packageName>
-				<script>function wotmudmapper:setConfigs()
-    local defaults = self.defaults or {}
-    local configs = self.configs or {}
-    local default_colors = self.default_map_colors or {}
-    local colors = self.map_colors or {}
-    
-    self:echo("Loading map configurations.\n")
-    -- load stored configs from file if it exists
-    if io.exists(getMudletHomeDir().."/wotmudmapper.configs.lua") then
-        table.load(getMudletHomeDir().."/wotmudmapper.configs.lua",configs)
-    end
-    if io.exists(getMudletHomeDir().."/wotmudmapper.map_colors.lua") then
-        table.load(getMudletHomeDir().."/wotmudmapper.map_colors.lua",colors)
-    end
-    self:echo("Map configurations loaded.\n")
-    
-    -- overwrite default values with stored config values
-    configs = table.update(defaults, configs)
-    self.configs = table.deepcopy(configs)
-    table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", self.configs)
-    colors = table.update(default_colors, colors)
-    self.map_colors = table.deepcopy(colors)
-    table.save(getMudletHomeDir() .. "/wotmudmapper.map_colors.lua", self.map_colors)
+				<script>function wotmudmapper:set_configs()
+  --local copies of map configs/colors and their defaults
+  local defaults = table.deepcopy(self.defaults) or {}
+  local configs = table.deepcopy(self.configs) or {}
+  local default_colors = table.deepcopy(self.default_map_colors) or {}
+  local colors = table.deepcopy(self.map_colors) or {}
+  
+  --if config and color files exist on disk, load them in  
+  self:echo("Loading map configurations.\n")
+  -- load stored configs from file if it exists
+  if io.exists(getMudletHomeDir().."/wotmudmapper.configs.lua") then
+      table.load(getMudletHomeDir().."/wotmudmapper.configs.lua",configs)
+  end
+  if io.exists(getMudletHomeDir().."/wotmudmapper.map_colors.lua") then
+      table.load(getMudletHomeDir().."/wotmudmapper.map_colors.lua",colors)
+  end
+  self:echo("Map configurations loaded.\n")
+  
+  -- overwrite default values with stored config values and save to disk
+  configs = table.update(defaults, configs)
+  self.configs = table.deepcopy(configs)
+  table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", self.configs)
+  colors = table.update(default_colors, colors)
+  self.map_colors = table.deepcopy(colors)
+  table.save(getMudletHomeDir() .. "/wotmudmapper.map_colors.lua", self.map_colors)
 end
 </script>
 				<eventHandlerList />
@@ -237,25 +251,32 @@ end
 				<name>MapOnSysConnectionEvent</name>
 				<packageName></packageName>
 				<script>function MapOnSysConnectionEvent(event)
+  --ensure the movement queue is empty
   wotmudmapper.queue = List:new()
-  wotmudmapper:setConfigs()
+  --set configuration values
+  wotmudmapper:set_configs()
   
-  wotmudmapper:showMap(wotmudmapper.configs.map_window.visible)
+  --show map window
+  wotmudmapper:show_map(wotmudmapper.configs.map_window.visible)
   
-  wotmudmapper:setMapColors()
+  --set colors and center on player location
+  wotmudmapper:set_map_colors()
   wotmudmapper.currentID={wotmudmapper.configs.roomID}
   centerview(wotmudmapper.currentID[1])
   
+  --ensure that offline mode is disabled
+  wotmudmapper.configs.offline=false
   disableKey("Offline Map")
   disableAlias("Offline Map Dirs")
   disableAlias("Offline Map Look")
   
+  --add map right click options and register their event handlers
   addMapMenu("Update room information")
-  addMapEvent("onMapUpdateRoomName", "onMapUpdateRoomName", "Update room information", "Update room name") 
-  addMapEvent("onMapUpdateRoomDesc", "onMapUpdateRoomDesc", "Update room information", "Update room description")
+  addMapEvent("OnMapUpdateRoomName", "OnMapUpdateRoomName", "Update room information", "Update room name") 
+  addMapEvent("OnMapUpdateRoomDesc", "OnMapUpdateRoomDesc", "Update room information", "Update room description")
   
-  registerAnonymousEventHandler("onMapUpdateRoomName", "onMapUpdateRoomName")
-  registerAnonymousEventHandler("onMapUpdateRoomDesc", "onMapUpdateRoomDesc")
+  registerAnonymousEventHandler("OnMapUpdateRoomName", "OnMapUpdateRoomName")
+  registerAnonymousEventHandler("OnMapUpdateRoomDesc", "OnMapUpdateRoomDesc")
 end</script>
 				<eventHandlerList>
 					<string>sysLoadEvent</string>
@@ -266,18 +287,21 @@ end</script>
 				<name>MapOnSysDisconnectionEvent</name>
 				<packageName></packageName>
 				<script>function MapOnSysDisconnectionEvent()
+  --set config values in preparation for disconnection
   wotmudmapper.configs = wotmudmapper.configs or {}
   wotmudmapper.configs.mapping = false
   wotmudmapper.configs.forceroom = false
   wotmudmapper.configs.offline=false
   wotmudmapper.map_colors = wotmudmapper.map_colors or {}
   
+  --if player location was known, save, otherwise set to mudlet roomID 1
   if table.size(wotmudmapper.currentID) == 1 then
     wotmudmapper.configs.roomID=wotmudmapper.currentID[1]
   else
     wotmudmapper.configs.roomID=1
   end
   
+  --save configs and colors to disk
   wotmudmapper:echo("Saving map configurations.\n")
   table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.configs)
   table.save(getMudletHomeDir() .. "/wotmudmapper.map_colors.lua", wotmudmapper.map_colors)
@@ -292,14 +316,17 @@ end</script>
 				<name>WoTMUDMapUpdate</name>
 				<packageName></packageName>
 				<script>function WoTMUDMapUpdate(event, filename)
-  -- is the file that downloaded ours?
+  --if the file that downloaded is not the map, return
   if not filename:find("WoTMUD_map.dat", 1, true) then
     return
   end
+  
+  --load in map file, set colors, and center on current player room
   wotmudmapper:echo("Download complete.\n")
   loadMap(filename)
   wotmudmapper:echo("New map successfully uploaded.\n")
-  wotmudmapper:setMapColors()
+  wotmudmapper:set_map_colors()
+  centerview(wotmudmapper.currentID[1])
 end</script>
 				<eventHandlerList>
 					<string>sysDownloadDone</string>
@@ -308,13 +335,16 @@ end</script>
 			<Script isActive="yes" isFolder="no">
 				<name>Show Map</name>
 				<packageName></packageName>
-				<script>function wotmudmapper:showMap(bval)
+				<script>function wotmudmapper:show_map(bval)
+  --set boolean of whether map is visible or not
   local visible = bval
   self.configs.map_window.visible = visible
   
-  local configs = self.configs.map_window
+  --local copy of map window config values
+  local configs = table.deepcopy(self.configs.map_window)
   local x, y, w, h = configs.x, configs.y, configs.w, configs.h
   
+  --if widget is used, open or close and return
   if configs.widget then
     if visible then
       openMapWidget()
@@ -324,6 +354,7 @@ end</script>
     return
   end
   
+  --create mapper container, position it, and resize it
   wotmudmapper.container = wotmudmapper.container or Adjustable.Container:new(
     {
       name = "mapper_container",
@@ -345,23 +376,28 @@ end</script>
   
   setMapZoom(configs.zoom)
   
+  --show or hide mapper container
   if visible then
     wotmudmapper.container:show()
   else
     wotmudmapper.container:hide()
   end
   
+  --strip numeric values from mapper container position and size (since they are stored as percent strings)
   x = tonumber(string.sub(x,1,-2))
   y = tonumber(string.sub(y,1,-2))
   w = tonumber(string.sub(w,1,-2))
   h = tonumber(string.sub(h,1,-2))
   
+  --account for negative values being measured from right or bottom of screen
   if x &lt; 0 then
     x = x+100
   end
   if y &lt; 0 then
     y = y + 100
   end
+  
+  --allow map to dock on the left or right of the screen if the center of the mapper is left or right of the screen midpoint
   if configs.dock then
     if x + 0.5*w &gt; 50 then
         wotmudmapper.container:attachToBorder("right")
@@ -377,10 +413,13 @@ end</script>
 			<Script isActive="yes" isFolder="no">
 				<name>Map Window Reposition</name>
 				<packageName></packageName>
-				<script>function mapFinishedRepositioning(eventName, containerName, width, height, x, y)
+				<script>function MapFinishedRepositioning(eventName, containerName, width, height, x, y)
+  --if the Adjustable.Container is not the mapper, return
   if containerName ~= "mapper_container" then
     return
   end
+  
+  --get main window size. convert Adjustable.Container values to percentages, store, and save to disk
   local mx, my = getMainWindowSize()
   x = x/mx*100
   y = y/my*100
@@ -393,10 +432,10 @@ end</script>
   wotmudmapper.configs.map_window.h = height.."%"
   table.save(getMudletHomeDir() .. "/wotmudmapper.configs.lua", wotmudmapper.configs)
   
-  wotmudmapper:showMap(true)
+  wotmudmapper:show_map(true)
 end
 
-registerAnonymousEventHandler("AdjustableContainerRepositionFinish", "mapFinishedRepositioning")</script>
+registerAnonymousEventHandler("AdjustableContainerRepositionFinish", "MapFinishedRepositioning")</script>
 				<eventHandlerList />
 			</Script>
 			<Script isActive="yes" isFolder="no">
@@ -413,7 +452,7 @@ registerAnonymousEventHandler("AdjustableContainerRepositionFinish", "mapFinishe
     cmd = 1
   end
   for w in self.help[cmd]:gmatch("(.-)\n") do
-    local before, target, text, after = w:match("(.*)&lt;link: (.-)&gt;(.*)&lt;\/link&gt;(.*)")
+    local before, target, text, after = w:match("(.*)&lt;link: (.*)&gt;(.*)&lt;\/link&gt;(.*)")
     if target then
       cecho(before)
       fg("yellow")
@@ -663,11 +702,11 @@ wotmudmapper.help.misc =
 			<Script isActive="yes" isFolder="no">
 				<name>Map Right Click to Update Room Information</name>
 				<packageName></packageName>
-				<script>function onMapUpdateRoomName(event)
+				<script>function OnMapUpdateRoomName(event)
   local rooms = getMapSelection()["rooms"]
-  if table.size(rooms)==0 then
+  if table.is_empty(rooms) then
     wotmudmapper:echo("No room selected.\n",false,true)
-  elseif table.size(rooms)~=1 then
+  elseif table.size(rooms) &gt; 1 then
     wotmudmapper:echo("More than one room selected.\n",false,true)
   else
     wotmudmapper:echo("Room name for room ID ("..rooms[1]..") updated from ("..getRoomName(rooms[1])..") to ("..wotmudmapper.roomname..")\n")
@@ -676,11 +715,11 @@ wotmudmapper.help.misc =
   updateMap()
 end
 
-function onMapUpdateRoomDesc(event)
+function OnMapUpdateRoomDesc(event)
   local rooms = getMapSelection()["rooms"]
-  if table.size(rooms)==0 then
+  if table.is_empty(rooms) then
     wotmudmapper:echo("No room selected.\n",false,true)
-  elseif table.size(rooms)~=1 then
+  elseif table.size(rooms) &gt; 1 then
     wotmudmapper:echo("More than one room selected.\n",false,true)
   else
     wotmudmapper:echo("Room description for room ID ("..rooms[1]..") updated.\n")
@@ -1201,7 +1240,7 @@ end
 				<Script isActive="yes" isFolder="no">
 					<name>Show Room List</name>
 					<packageName></packageName>
-					<script>function wotmudmapper:showRoomList(areaid)
+					<script>function wotmudmapper:show_room_list(areaid)
   local listcolor, othercolor = "DarkSlateGrey", "LightSlateGray"
   local roomlist, endresult = getAreaRooms(areaid) or {}, {}
   -- obtain a roomname list for each of the room IDs we got
@@ -1239,7 +1278,7 @@ end</script>
 				<Script isActive="yes" isFolder="no">
 					<name>Show Area List</name>
 					<packageName></packageName>
-					<script>function wotmudmapper:showAreaList()
+					<script>function wotmudmapper:show_area_list()
     local totalroomcount = 0
     local rlist = getAreaTableSwap()
     local listcolor, othercolor = "DarkSlateGrey","LightSlateGray"
@@ -1259,7 +1298,7 @@ end</script>
         if rlist[id] then
             cecho(string.format("&lt;%s&gt;%10d ", othercolor, id))
             fg(listcolor)
-            echoLink(string.format("%-30s (%d rooms)",rlist[id],countrooms(id)), [[wotmudmapper:showRoomList(]]..id..[[)]],
+            echoLink(string.format("%-30s (%d rooms)",rlist[id],countrooms(id)), [[wotmudmapper:show_room_list(]]..id..[[)]],
                 "View the room list for "..rlist[id], true)
             echo("\n")
         end
@@ -1276,10 +1315,10 @@ end</script>
   --if installed file is not the desired one
   if name ~= "mapper_scripts" then return end
   wotmudmapper:show_help()
-  wotmudmapper:setConfigs()
-  wotmudmapper:setMapColors()
+  wotmudmapper:set_configs()
+  wotmudmapper:set_map_colors()
   
-  wotmudmapper:showMap(wotmudmapper.configs.map_window.visible)
+  wotmudmapper:show_map(wotmudmapper.configs.map_window.visible)
 end</script>
 				<eventHandlerList>
 					<string>sysInstallPackage</string>
@@ -1289,8 +1328,12 @@ end</script>
 				<name>doSpeedWalk</name>
 				<packageName></packageName>
 				<script>function doSpeedWalk()
-  for k, v in pairs(speedWalkDir) do
-    send(v)
+  if table.size(wotmudmapper.currentID) == 1 then
+    for k, v in pairs(speedWalkDir) do
+      send(v)
+    end
+  else
+    wotmudmapper:echo("Current room not known.\n", false, true)
   end
 end</script>
 				<eventHandlerList />
@@ -1622,6 +1665,16 @@ enableMapInfo("Door info")
 ["Fortress of Light Dungeon"] = "Fortress_of_Light_Dungeon"
 
 }</script>
+				<eventHandlerList />
+			</Script>
+			<Script isActive="yes" isFolder="no">
+				<name>Set Player Location</name>
+				<packageName></packageName>
+				<script>registerAnonymousEventHandler("sysManualLocationSetEvent", "set_player_location")
+
+function set_player_location(event, args)
+  wotmudmapper.currentID={args}
+end</script>
 				<eventHandlerList />
 			</Script>
 		</ScriptGroup>

--- a/triggers/mapper_triggers.xml
+++ b/triggers/mapper_triggers.xml
@@ -110,9 +110,7 @@ end</script>
 wotmudmapper.roomexits = string.lower(matches[2])
 wotmudmapper:echo("\nRoom exits (" .. wotmudmapper.roomexits .. ") captured.\n", true)
 wotmudmapper.roomexits = string.split(wotmudmapper.roomexits)
-while table.index_of(wotmudmapper.roomexits, "") do
-  table.remove(wotmudmapper.roomexits, table.index_of(wotmudmapper.roomexits, ""))
-end
+wotmudmapper.roomexits = table.n_intersection(wotmudmapper.roomexits,{"n","e","s","w","u","d"})
 
 local mapCommand, x, y, z, lastID, tempID
 --Specifying the type of movement. If not fleeing or following, then take from queue
@@ -299,7 +297,7 @@ end</script>
 				</TriggerGroup>
 			</TriggerGroup>
 			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
-				<name>Night/Blind Movement</name>
+				<name>Night/Blind/Fog Movement</name>
 				<script>if not wotmudmapper.dark then
   wotmudmapper.dark = true
 end
@@ -702,12 +700,11 @@ end</script>
 					<integer>1</integer>
 				</regexCodePropertyList>
 			</Trigger>
-			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+			<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>Resuming Trigger</name>
-				<script>if wotmudmapper.pausing then
-  wotmudmapper.pausing = false
-  wotmudmapper.queue = List:new()
-end</script>
+				<script>wotmudmapper.pausing = false
+wotmudmapper.queue = List:new()
+disableTrigger("Resuming Trigger")</script>
 				<triggerType>0</triggerType>
 				<conditonLineDelta>0</conditonLineDelta>
 				<mStayOpen>0</mStayOpen>
@@ -720,14 +717,19 @@ end</script>
 				<colorTriggerBgColor>#000000</colorTriggerBgColor>
 				<regexCodeList>
 					<string>HP:(\S+) MV:(\S+)</string>
+					<string>HP:(\S+) SP:(\S+) MV:(\S+)</string>
+					<string>HP:(\S+) DP:(\S+) MV:(\S+)</string>
 				</regexCodeList>
 				<regexCodePropertyList>
+					<integer>1</integer>
+					<integer>1</integer>
 					<integer>1</integer>
 				</regexCodePropertyList>
 			</Trigger>
 			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>Pausing Trigger</name>
-				<script>wotmudmapper.pausing = true</script>
+				<script>wotmudmapper.pausing = true
+enableTrigger("Resuming Trigger")</script>
 				<triggerType>0</triggerType>
 				<conditonLineDelta>0</conditonLineDelta>
 				<mStayOpen>0</mStayOpen>
@@ -739,7 +741,7 @@ end</script>
 				<colorTriggerFgColor>#000000</colorTriggerFgColor>
 				<colorTriggerBgColor>#000000</colorTriggerBgColor>
 				<regexCodeList>
-					<string>\* Press \&lt;Return\&gt; to continue, q to quit \*\&gt;$</string>
+					<string>\* Press &lt;Return&gt; to continue, q to quit \*&gt;$</string>
 				</regexCodeList>
 				<regexCodePropertyList>
 					<integer>1</integer>


### PR DESCRIPTION
Fixed a(n embarrassing) bug where movement commands entered after the "* Press <Return> to continue, q to quit *>" line of a multipage who list (and possibly other commands that produce this output) remained in the movement queue, rather than the queue being reset on the next prompt line.
This is the likely cause of some door command failures on channelers and fades. I would highly recommend anyone experiencing issues with the door commands to update their map scripts, and continue to let me know when such issues occur. Thanks to the anonymous MC who let me know of this issue :)

Add comments to various parts of code for clarity
Edited some internal function names to be slightly more consistent with case and style
Edited the speedwalk function to prevent speed walking if your current room is not known
Added the necessary event handler so that the right click option to set player location works with my scripts (mostly useful if you need to do stuff with the map in offline mode and want to set a location quickly)
Edited a couple triggers so something is not firing on every prompt line
Added a speedwalk alias. You can now type a period followed by a list of number + command directions to have the map enter those. E.g., you can type .5n2ws1e3n and the alias will send 5 north commands, 2 w commands, a south command, an east command, and 3 north commands. Including the number 1 for singles of a direction is optional.
